### PR TITLE
feat: support select multiple game role, when request api /event/trigger

### DIFF
--- a/src/main/java/com/itplh/hero/annotation/Required.java
+++ b/src/main/java/com/itplh/hero/annotation/Required.java
@@ -1,0 +1,12 @@
+package com.itplh.hero.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * 表示该参数为必须的
+ */
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Required {
+}

--- a/src/main/java/com/itplh/hero/domain/EventTriggerBody.java
+++ b/src/main/java/com/itplh/hero/domain/EventTriggerBody.java
@@ -1,0 +1,30 @@
+package com.itplh.hero.domain;
+
+import com.itplh.hero.annotation.Required;
+import lombok.Data;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Data
+public class EventTriggerBody {
+
+    @Required
+    private String eventName;
+    @Required
+    private Collection<String> sids;
+    /**
+     * 目标运行次数
+     * <p>
+     * 默认值为1，表示运行1次
+     * -1表示无限次
+     */
+    private Long targetRunRound = 1L;
+    /**
+     * 额外的扩展信息
+     * <p>
+     * extendInfo parameter detail, please see {@link com.itplh.hero.constant.ParameterEnum}
+     */
+    private Map<String, String> extendInfo;
+
+}


### PR DESCRIPTION
For example, 3 game role trigger NPCBenefitsEvent

`POST /event/trigger`

```json
{
  "eventName": "NPCBenefitsEvent",
  "sids": [
    "yn3rcj5njv6ns71v6m3jp",
    "3vl3uh5nk9rino2x06vhd",
    "jarlzm5nl9jv534pf6co6"
  ],
  "targetRunRound": 1,
  "extendInfo": {
    "resources": "benefits-open-today-spiritual-cultivation"
  }
}
```